### PR TITLE
 Fix bug in LinkedIn API endpoint used for the getUserInfo method

### DIFF
--- a/src/GuzzleOauth/Consumer/LinkedIn.json
+++ b/src/GuzzleOauth/Consumer/LinkedIn.json
@@ -6,7 +6,7 @@
     "operations": {
        "getUserInfo": {
             "httpMethod": "GET",
-            "uri": "me?projection=(id,firstName,lastName,profilePicture(displayImage~:playableStreams))",
+            "uri": "me?projection=(id,localizedFirstName,localizedLastName,profilePicture(displayImage~:playableStreams))",
             "summary": "Returns the account info for the authenticating user.",
             "responseClass": "JsonOutput",
             "additionalParameters": {


### PR DESCRIPTION
The name of the LinkedIn user is retrieved by using the values of _localizedFirstName_ and _localizedLastName_ 